### PR TITLE
Require active_support explicitly

### DIFF
--- a/lib/safe_attributes.rb
+++ b/lib/safe_attributes.rb
@@ -1,3 +1,5 @@
+require 'active_support'
+
 module SafeAttributes
   extend ActiveSupport::Concern
 


### PR DESCRIPTION
I was getting an "uninitialized constant SafeAttributes::ActiveSupport" error when attempting to use safe_attributes outside of a rails project. Adding require 'active_support' fixes the issue. 

I did not write a test because I'm unsure of how to effectively recreate the issue with a spec.
