### PR TITLE
Redifine AR::Base#attribute_change to fix an issue with dirty attributes

### DIFF
--- a/lib/safe_attributes/base.rb
+++ b/lib/safe_attributes/base.rb
@@ -63,5 +63,10 @@ module SafeAttributes
       end
     end
 
+    def attribute_change(attr)
+      return if self.class.bad_attribute_names.include?(attr.to_sym)
+      [changed_attributes[attr], __send__(attr)] if attribute_changed?(attr)
+    end
+
   end
 end


### PR DESCRIPTION
My table schema (note the "association" attribute):

``` sql
CREATE TABLE `resource_project_association` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `resource_id` int(10) unsigned NOT NULL,
  `project_id` int(10) unsigned NOT NULL,
  `association` enum('worker','observer') NOT NULL DEFAULT 'observer',
  PRIMARY KEY (`id`),
);
```

And my model:

``` ruby
class ProjectMembership < Membership
  include SafeAttributes::Base

  self.table_name = 'resource_project_association'
  bad_attribute_names :association
end
```

When i update the association attribute

``` ruby
>> m = ProjectMembership.first
>> m[:association] = 'worker'
>> m.save
```

It successfuly update the database, but crash when updating attributes
changes in the model:

```
gems/activerecord-3.2.9/lib/active_record/associations.rb:155:in `association'
gems/activemodel-3.2.9/lib/active_model/dirty.rb:143:in `attribute_change'
gems/activemodel-3.2.9/lib/active_model/dirty.rb:117:in `block in changes'
gems/activemodel-3.2.9/lib/active_model/dirty.rb:117:in `map'
gems/activemodel-3.2.9/lib/active_model/dirty.rb:117:in `changes'
gems/activerecord-3.2.9/lib/active_record/attribute_methods/dirty.rb:23:in `save'
gems/activerecord-3.2.9/lib/active_record/transactions.rb:259:in `block (2 levels) in save'
gems/activerecord-3.2.9/lib/active_record/transactions.rb:313:in `block in with_transaction_returning_status'
gems/activerecord-3.2.9/lib/active_record/connection_adapters/abstract/database_statements.rb:192:in `transaction'
gems/activerecord-3.2.9/lib/active_record/transactions.rb:208:in `transaction'
gems/activerecord-3.2.9/lib/active_record/transactions.rb:311:in `with_transaction_returning_status'
gems/activerecord-3.2.9/lib/active_record/transactions.rb:259:in `block in save'
gems/activerecord-3.2.9/lib/active_record/transactions.rb:270:in `rollback_active_record_state!'
gems/activerecord-3.2.9/lib/active_record/transactions.rb:258:in `save'
```

This patch fix the issue for me, but I was not able to reproduce it in the test suite.
I'll retry later, but maybe you can help me guess why.

Regards
